### PR TITLE
Fix version check

### DIFF
--- a/Update-TacO.ps1
+++ b/Update-TacO.ps1
@@ -150,10 +150,8 @@ $tacolinks = $(
 )
 # Just grab the very top link
 $tacolatest = $tacolinks.firstChild.firstChild.firstChild
-# Set the dropbox shortcut to auto-download
-$tacolink = $tacolatest.href.replace('dl=0', 'dl=1')
 # Grab only the build of the latest version
-$tacoversion = $tacolatest.innerHTML.split(' ')[-1]
+$tacoversion = $tacolatest.innerHTML.split('/')[-2]
 
 Write-Host "Identified newest available TacO version $tacoversion."
 if ( $state.ContainsKey('tacoversion') ) {


### PR DESCRIPTION
Download url has changed since TacO switched from Dropbox to Github, therefore version check need a fix.